### PR TITLE
Fix experience IV bag item

### DIFF
--- a/src/main/java/com/hbm/items/ModItems.java
+++ b/src/main/java/com/hbm/items/ModItems.java
@@ -350,7 +350,8 @@ public class ModItems {
 	public static final Item iv_xp_empty = new ItemSimpleConsumable("iv_xp_empty").setUseActionServer((stack, user) -> {
 			if(user.experienceTotal >= 100) {
 				ItemSimpleConsumable.giveSoundAndDecrement(stack, user, HBMSoundHandler.syringeUse, new ItemStack(ModItems.iv_xp));
-				user.addExperience(-100);
+				EnchantmentUtil.removeExperience(user, 100);
+				user.inventory.markDirty();
 			}
 		}).setMaxStackSize(16).setCreativeTab(MainRegistry.consumableTab);
 		

--- a/src/main/java/com/hbm/items/ModItems.java
+++ b/src/main/java/com/hbm/items/ModItems.java
@@ -351,7 +351,6 @@ public class ModItems {
 			if(user.experienceTotal >= 100) {
 				ItemSimpleConsumable.giveSoundAndDecrement(stack, user, HBMSoundHandler.syringeUse, new ItemStack(ModItems.iv_xp));
 				EnchantmentUtil.removeExperience(user, 100);
-				user.inventory.markDirty();
 			}
 		}).setMaxStackSize(16).setCreativeTab(MainRegistry.consumableTab);
 		

--- a/src/main/java/com/hbm/items/ModItems.java
+++ b/src/main/java/com/hbm/items/ModItems.java
@@ -350,13 +350,13 @@ public class ModItems {
 	public static final Item iv_xp_empty = new ItemSimpleConsumable("iv_xp_empty").setUseActionServer((stack, user) -> {
 			if(user.experienceTotal >= 100) {
 				ItemSimpleConsumable.giveSoundAndDecrement(stack, user, HBMSoundHandler.syringeUse, new ItemStack(ModItems.iv_xp));
-				EnchantmentUtil.setExperience(user, user.experienceTotal - 100);
+				user.addExperience(-100);
 			}
 		}).setMaxStackSize(16).setCreativeTab(MainRegistry.consumableTab);
 		
 	public static final Item iv_xp = new ItemSimpleConsumable("iv_xp").setUseActionServer((stack, user) -> {
 			ItemSimpleConsumable.giveSoundAndDecrement(stack, user, SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP, new ItemStack(ModItems.iv_xp_empty));
-			EnchantmentUtil.addExperience(user, 100, false);
+			user.addExperience(100);
 		}).setMaxStackSize(16).setCreativeTab(MainRegistry.consumableTab);
 		
 	public static final Item iv_empty = new ItemSimpleConsumable("iv_empty").setUseActionServer((stack, user) -> {

--- a/src/main/java/com/hbm/util/EnchantmentUtil.java
+++ b/src/main/java/com/hbm/util/EnchantmentUtil.java
@@ -27,4 +27,31 @@ public class EnchantmentUtil {
 		if(stack.getEnchantmentTagList().tagCount() == 0)
 			stack.getTagCompound().removeTag("ench");
 	}
+
+	/**
+	 * Removes an amount of experience from a player and updates their level
+	 * @param entityPlayer the player to remove experience from
+	 * @param amount the amount of experience to remove
+	 */
+	public static void removeExperience(EntityPlayer entityPlayer, float amount) {
+		if (entityPlayer.experienceTotal - amount <= 0) {
+			entityPlayer.experienceLevel = 0;
+			entityPlayer.experience = 0;
+			entityPlayer.experienceTotal = 0;
+			return;
+		}
+
+		entityPlayer.experienceTotal -= amount;
+		if (entityPlayer.experience * (float)entityPlayer.xpBarCap() < amount) {
+			amount -= entityPlayer.experience * (float)entityPlayer.xpBarCap();
+			entityPlayer.experience = 1.0f;
+			entityPlayer.experienceLevel--;
+		}
+
+		while (entityPlayer.xpBarCap() < amount) {
+			amount -= entityPlayer.xpBarCap();
+			entityPlayer.experienceLevel--;
+		}
+		entityPlayer.experience -= amount / (float)entityPlayer.xpBarCap();
+	}
 }

--- a/src/main/java/com/hbm/util/EnchantmentUtil.java
+++ b/src/main/java/com/hbm/util/EnchantmentUtil.java
@@ -29,67 +29,6 @@ public class EnchantmentUtil {
 	}
 
 	public static int xpBarCap(int level) {
-        return level >= 30 ? 62 + (level - 30) * 7 : (level >= 15 ? 17 + (level - 15) * 3 : 17);
-    }
-
-    public static int getLevelForExperience(int xp) {
-    	
-		int level = 0;
-		
-		while (true) {
-			
-			int xpCap = xpBarCap(level);
-			
-			if (xp < xpCap)
-				return level;
-			
-			xp -= xpCap;
-			level++;
-		}
-	}
-
-	public static void addExperience(EntityPlayer player, int xp, boolean silent) {
-
-		int j = Integer.MAX_VALUE - player.experienceTotal;
-
-		if(xp > j) {
-			xp = j;
-		}
-
-		player.experience += (float) xp / (float) player.xpBarCap();
-
-		for(player.experienceTotal += xp; player.experience >= 1.0F; player.experience /= (float) player.xpBarCap()) {
-			player.experience = (player.experience - 1.0F) * (float) player.xpBarCap();
-
-			if(silent)
-				addExperienceLevelSilent(player, 1);
-			else
-				player.addExperienceLevel(1);
-		}
-	}
-
-	public static void setExperience(EntityPlayer player, int xp) {
-
-		player.experienceLevel = 0;
-		player.experience = 0.0F;
-		player.experienceTotal = 0;
-
-		addExperience(player, xp, true);
-	}
-
-	public static void addExperienceLevelSilent(EntityPlayer player, int level) {
-		player.experienceLevel += level;
-
-		if(player.experienceLevel < 0) {
-			player.experienceLevel = 0;
-			player.experience = 0.0F;
-			player.experienceTotal = 0;
-		}
-	}
-
-	/** Fun fact: experienceTotal lies in 1.7.10 and has no actual purpose other than misleading people! */
-	/** Fun fact: experienceTotal lies no more in 1.12.2 yay */
-	public static int getTotalExperience(EntityPlayer player) {
-		return player.experienceTotal;
+		return level >= 30 ? 62 + (level - 30) * 7 : (level >= 15 ? 17 + (level - 15) * 3 : 17);
 	}
 }

--- a/src/main/java/com/hbm/util/EnchantmentUtil.java
+++ b/src/main/java/com/hbm/util/EnchantmentUtil.java
@@ -27,8 +27,4 @@ public class EnchantmentUtil {
 		if(stack.getEnchantmentTagList().tagCount() == 0)
 			stack.getTagCompound().removeTag("ench");
 	}
-
-	public static int xpBarCap(int level) {
-		return level >= 30 ? 62 + (level - 30) * 7 : (level >= 15 ? 17 + (level - 15) * 3 : 17);
-	}
 }


### PR DESCRIPTION
Overview of changes:

- Swap to using 1.12.2 experience methods in EntityPlayer for experience iv bags.
- Remove most unused functions in EnchantmentUtil; reimplement removeExperience().

Should address funny business with experience IV bag. Tested in my environment, added and removed levels from player without any free XP being magically added in some cases.