### PR TITLE
Add config settings for oil harvesting machines

### DIFF
--- a/src/main/java/com/hbm/config/MachineConfig.java
+++ b/src/main/java/com/hbm/config/MachineConfig.java
@@ -6,8 +6,8 @@ public class MachineConfig {
 
 	public static int delayPerOperationDerrick = 50;
 	public static int powerConsumptionPerOperationDerrick = 100;
-	public static int oilPerDepositBlockMinDerrick = 500;
 
+	public static int oilPerDepositBlockMinDerrick = 500;
 	public static int oilPerDepositBlockMaxExtraDerrick = 0;
 	public static int gasPerDepositBlockMinDerrick = 100;
 	public static int gasPerDepositBlockMaxExtraDerrick = 401;

--- a/src/main/java/com/hbm/config/MachineConfig.java
+++ b/src/main/java/com/hbm/config/MachineConfig.java
@@ -4,8 +4,78 @@ import net.minecraftforge.common.config.Configuration;
 
 public class MachineConfig {
 
-	public static void loadFromConfig(Configuration config) {
+	public static int delayPerOperationDerrick = 50;
+	public static int powerConsumptionPerOperationDerrick = 100;
+	public static int oilPerDepositBlockMinDerrick = 500;
 
+	public static int oilPerDepositBlockMaxExtraDerrick = 0;
+	public static int gasPerDepositBlockMinDerrick = 100;
+	public static int gasPerDepositBlockMaxExtraDerrick = 401;
+
+
+	public static int delayPerOperationPumpjack = 25;
+	public static int powerConsumptionPerOperationPumpjack = 200;
+	public static int oilPerDepositBlockMinPumpjack = 650;
+
+	public static int oilPerDepositBlockMaxExtraPumpjack = 0;
+	public static int gasPerDepositBlockMinPumpjack = 110;
+	public static int gasPerDepositBlockMaxExtraPumpjack = 401;
+
+	public static int delayPerOperationFrackingTower = 20;
+	public static int powerConsumptionPerOperationFrackingTower = 5000;
+	public static int solutionConsumptionPerOperationFrackingTower = 10;
+	public static int worldDestructionRangeFrackingTower = 32;
+
+	public static int oilPerDepositBlockMinFrackingTower = 1000;
+	public static int oilPerDepositBlockMaxExtraFrackingTower = 0;
+	public static int gasPerDepositBlockMinFrackingTower = 200;
+	public static int gasPerDepositBlockMaxExtraFrackingTower = 401;
+
+	public static int oilPerBedrockDepositBlockMinFrackingTower = 100;
+	public static int oilPerBedrockDepositBlockMaxExtraFrackingTower = 0;
+	public static int gasPerBedrockDepositBlockMinFrackingTower = 10;
+	public static int gasPerBedrockDepositBlockMaxExtraFrackingTower = 50;
+
+	private static String generateConfigName(int idx, String fieldName) {
+		return String.format("9.%02d_%s", idx, fieldName);
+	}
+
+	public static void loadFromConfig(Configuration config) {
 		final String CATEGORY_MACHINE = "09_machines";
+
+		// Oil derrick settings
+		delayPerOperationDerrick = CommonConfig.createConfigInt(config, CATEGORY_MACHINE, generateConfigName(0, "delayPerOperationDerrick"), "Controls how much delay between extraction or drilling operations for Oil Derricks", 50);
+		powerConsumptionPerOperationDerrick = CommonConfig.createConfigInt(config, CATEGORY_MACHINE, generateConfigName(1, "powerConsumptionPerOperationDerrick"), "Controls how much power is consumed per operation for Oil Derricks", 100);
+
+		oilPerDepositBlockMinDerrick = CommonConfig.createConfigInt(config, CATEGORY_MACHINE, generateConfigName(2, "oilPerDepositBlockMinDerrick"), "Controls how much crude oil at minimum is extracted per deposit block for Oil Derricks", 500);
+		oilPerDepositBlockMaxExtraDerrick = CommonConfig.createConfigInt(config, CATEGORY_MACHINE, generateConfigName(3, "oilPerDepositBlockMaxExtraDerrick"), "Controls how much extra crude oil can be extracted per deposit block for Oil Derricks", 0);
+		gasPerDepositBlockMinDerrick = CommonConfig.createConfigInt(config, CATEGORY_MACHINE, generateConfigName(4, "gasPerDepositBlockMinDerrick"), "Controls how much natrual gas at minimum is extracted per deposit block for Oil Derricks", 100);
+		gasPerDepositBlockMaxExtraDerrick = CommonConfig.createConfigInt(config, CATEGORY_MACHINE, generateConfigName(5, "gasPerDepositBlockMaxExtraDerrick"), "Controls how much extra natrual gas can be extracted per deposit block for Oil Derricks", 401);
+
+		// Pumpjack settings
+		delayPerOperationPumpjack = CommonConfig.createConfigInt(config, CATEGORY_MACHINE, generateConfigName(6, "delayPerOperationPumpjack"), "Controls how much delay between extraction or drilling operations for Pumpjacks", 25);
+		powerConsumptionPerOperationPumpjack = CommonConfig.createConfigInt(config, CATEGORY_MACHINE, generateConfigName(7, "powerConsumptionPerOperationPumpjack"), "Controls how much power is consumed per operation for Pumpjacks", 200);
+
+		oilPerDepositBlockMinPumpjack = CommonConfig.createConfigInt(config, CATEGORY_MACHINE, generateConfigName(8, "oilPerDepositBlockMinPumpjack"), "Controls how much crude oil at minimum is extracted per deposit block for Pumpjacks", 650);
+		oilPerDepositBlockMaxExtraPumpjack = CommonConfig.createConfigInt(config, CATEGORY_MACHINE, generateConfigName(9, "oilPerDepositBlockMaxExtraPumpjack"), "Controls how much extra crude oil can be extracted per deposit block for Pumpjacks", 0);
+		gasPerDepositBlockMinPumpjack = CommonConfig.createConfigInt(config, CATEGORY_MACHINE, generateConfigName(10, "gasPerDepositBlockMinPumpjack"), "Controls how much natrual gas at minimum is extracted per deposit block for Pumpjacks", 110);
+		gasPerDepositBlockMaxExtraPumpjack = CommonConfig.createConfigInt(config, CATEGORY_MACHINE, generateConfigName(11, "gasPerDepositBlockMaxExtraPumpjack"), "Controls how much extra natrual gas can be extracted per deposit block for Pumpjacks", 401);
+
+		// Fracking tower settings
+		delayPerOperationFrackingTower = CommonConfig.createConfigInt(config, CATEGORY_MACHINE, generateConfigName(12, "delayPerOperationFrackingTower"), "Controls how much delay between extraction or drilling operations for Fracking towers", 20);
+		powerConsumptionPerOperationFrackingTower = CommonConfig.createConfigInt(config, CATEGORY_MACHINE, generateConfigName(13, "powerConsumptionPerOperationFrackingTower"), "Controls how much power is consumed per operation for Fracking towers", 5000);
+		solutionConsumptionPerOperationFrackingTower = CommonConfig.createConfigInt(config, CATEGORY_MACHINE, generateConfigName(14, "solutionConsumptionPerOperationFrackingTower"), "Controls how much fracking solution is consumed per operation for Fracking towers", 10);
+		worldDestructionRangeFrackingTower = CommonConfig.createConfigInt(config, CATEGORY_MACHINE, generateConfigName(15, "worldDestructionRangeFrackingTower"), "Controls how far in blocks around a Fracking tower the world is affected during operation", 32);
+
+		oilPerDepositBlockMinFrackingTower = CommonConfig.createConfigInt(config, CATEGORY_MACHINE, generateConfigName(16, "oilPerDepositBlockMinFrackingTower"), "Controls how much crude oil at minimum is extracted per deposit block for Fracking towers", 1000);
+		oilPerDepositBlockMaxExtraFrackingTower = CommonConfig.createConfigInt(config, CATEGORY_MACHINE, generateConfigName(17, "oilPerDepositBlockMaxExtraFrackingTower"), "Controls how much extra crude oil can be extracted per deposit block for Fracking towers", 0);
+		gasPerDepositBlockMinFrackingTower = CommonConfig.createConfigInt(config, CATEGORY_MACHINE, generateConfigName(18, "gasPerDepositBlockMinFrackingTower"), "Controls how much natrual gas at minimum is extracted per deposit block for Fracking towers", 200);
+		gasPerDepositBlockMaxExtraFrackingTower = CommonConfig.createConfigInt(config, CATEGORY_MACHINE, generateConfigName(19, "gasPerDepositBlockMaxExtraFrackingTower"), "Controls how much extra natrual gas can be extracted per deposit block for Fracking towers", 401);
+
+		oilPerBedrockDepositBlockMinFrackingTower = CommonConfig.createConfigInt(config, CATEGORY_MACHINE, generateConfigName(20, "oilPerBedrockDepositBlockMinFrackingTower"), "Controls how much crude oil at minimum is extracted per bedrock deposit block for Fracking towers", 100);
+		oilPerBedrockDepositBlockMaxExtraFrackingTower = CommonConfig.createConfigInt(config, CATEGORY_MACHINE, generateConfigName(21, "oilPerBedrockDepositBlockMaxExtraFrackingTower"), "Controls how much extra crude oil can be extracted per bedrock deposit block for Fracking towers", 0);
+		gasPerBedrockDepositBlockMinFrackingTower = CommonConfig.createConfigInt(config, CATEGORY_MACHINE, generateConfigName(22, "gasPerBedrockDepositBlockMinFrackingTower"), "Controls how much natrual gas at minimum is extracted per bedrock deposit block for Fracking towers", 10);
+		gasPerBedrockDepositBlockMaxExtraFrackingTower = CommonConfig.createConfigInt(config, CATEGORY_MACHINE, generateConfigName(23, "gasPerBedrockDepositBlockMaxExtraFrackingTower"), "Controls how much extra natrual gas can be extracted per bedrock deposit block for Fracking towers", 50);
+
 	}
 }

--- a/src/main/java/com/hbm/config/MachineConfig.java
+++ b/src/main/java/com/hbm/config/MachineConfig.java
@@ -36,7 +36,7 @@ public class MachineConfig {
 	public static int gasPerBedrockDepositBlockMinFrackingTower = 10;
 	public static int gasPerBedrockDepositBlockMaxExtraFrackingTower = 50;
 
-	private static String generateConfigName(int idx, String fieldName) {
+	private static String generateConfigName(final int idx, final String fieldName) {
 		return String.format("9.%02d_%s", idx, fieldName);
 	}
 

--- a/src/main/java/com/hbm/tileentity/machine/oil/TileEntityMachineFrackingTower.java
+++ b/src/main/java/com/hbm/tileentity/machine/oil/TileEntityMachineFrackingTower.java
@@ -1,6 +1,7 @@
 package com.hbm.tileentity.machine.oil;
 
 import com.hbm.blocks.ModBlocks;
+import com.hbm.config.MachineConfig;
 import com.hbm.entity.particle.EntityGasFX;
 import com.hbm.forgefluid.FFUtils;
 import com.hbm.forgefluid.ModForgeFluids;
@@ -25,21 +26,6 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class TileEntityMachineFrackingTower extends TileEntityOilDrillBase {
 
-    protected static int consumption = 5000;
-    private static int solutionRequired = 10;
-
-    protected static int delay = 20;
-    protected static int oilPerDeposit = 1000;
-    protected static int gasPerDepositMin = 200;
-    
-    protected static int oilPerBedrockDeposit = 100;
-    protected static int gasPerBedrockDepositMin = 10;
-    protected static int extraGasPerDepositMax = 401;
-    protected static int extraGasPerBedrockDepositMax = 50;
-
-    protected static int destructionRange = 32;
-
-
     public TileEntityMachineFrackingTower() {
         super();
         tanks[2] = new FluidTank(64000);
@@ -55,7 +41,7 @@ public class TileEntityMachineFrackingTower extends TileEntityOilDrillBase {
 
     @Override
     public void update() {
-        int timer = delay;
+        int timer = MachineConfig.delayPerOperationFrackingTower;
 
         age++;
         age2++;
@@ -84,7 +70,7 @@ public class TileEntityMachineFrackingTower extends TileEntityOilDrillBase {
             }
             power = Library.chargeTEFromItems(inventory, 0, power, getMaxPower());
 
-            if(power >= consumption && tank2Amount >= solutionRequired && !(tank0Amount >= tanks[0].getCapacity() || tank1Amount >= tanks[1].getCapacity())) {
+            if(power >= MachineConfig.powerConsumptionPerOperationFrackingTower && tank2Amount >= MachineConfig.solutionConsumptionPerOperationFrackingTower && !(tank0Amount >= tanks[0].getCapacity() || tank1Amount >= tanks[1].getCapacity())) {
 
                 // operation start
 
@@ -116,17 +102,26 @@ public class TileEntityMachineFrackingTower extends TileEntityOilDrillBase {
                             if(succNumber != 0) {
 
                                 if (succNumber == 1) {
-                                    this.tanks[0].fill(new FluidStack(tankTypes[0], oilPerDeposit), true);
-                                    this.tanks[1].fill(new FluidStack(tankTypes[1], (gasPerDepositMin + world.rand.nextInt(extraGasPerDepositMax))), true);
-                                }
-                                else {
-                                    this.tanks[0].fill(new FluidStack(tankTypes[0], oilPerBedrockDeposit), true);
-                                    this.tanks[1].fill(new FluidStack(tankTypes[1], (gasPerBedrockDepositMin + world.rand.nextInt(extraGasPerBedrockDepositMax))), true);
+                                    int oilCollected = MachineConfig.oilPerDepositBlockMinFrackingTower + ((MachineConfig.oilPerDepositBlockMaxExtraFrackingTower > 0) ? world.rand.nextInt(MachineConfig.oilPerDepositBlockMaxExtraFrackingTower) : 0);
+                                    int gasCollected = MachineConfig.gasPerDepositBlockMinFrackingTower + ((MachineConfig.gasPerDepositBlockMaxExtraFrackingTower > 0) ? world.rand.nextInt(MachineConfig.oilPerDepositBlockMaxExtraFrackingTower) : 0);
+
+                                    this.tanks[0].fill(new FluidStack(tankTypes[0], oilCollected), true);
+                                    this.tanks[1].fill(new FluidStack(tankTypes[1], gasCollected), true);
+                                } else {
+                                    int oilCollected = MachineConfig.oilPerBedrockDepositBlockMinFrackingTower + ((MachineConfig.oilPerBedrockDepositBlockMaxExtraFrackingTower > 0) ? world.rand.nextInt(MachineConfig.oilPerDepositBlockMaxExtraFrackingTower) : 0);
+                                    int gasCollected = MachineConfig.gasPerBedrockDepositBlockMinFrackingTower + ((MachineConfig.gasPerBedrockDepositBlockMaxExtraFrackingTower > 0) ? world.rand.nextInt(MachineConfig.oilPerDepositBlockMaxExtraFrackingTower) : 0);
+
+                                    this.tanks[0].fill(new FluidStack(tankTypes[0], oilCollected), true);
+                                    this.tanks[1].fill(new FluidStack(tankTypes[1], gasCollected), true);
                                 }
                                 needsUpdate = true;
 
-                                tanks[2].drain(solutionRequired, true);
-                                OilSpot.generateOilSpot(world, pos.getX(), pos.getZ(), destructionRange, 10);
+                                tanks[2].drain(MachineConfig.solutionConsumptionPerOperationFrackingTower, true);
+
+                                int destructionRangeInBlocks = MachineConfig.worldDestructionRangeFrackingTower;
+                                if (destructionRangeInBlocks > 0) {
+                                    OilSpot.generateOilSpot(world, pos.getX(), pos.getZ(), destructionRangeInBlocks, 10);
+                                }
 
                                 break;
                             } else {
@@ -144,7 +139,7 @@ public class TileEntityMachineFrackingTower extends TileEntityOilDrillBase {
 
                 // operation end
 
-                power -= consumption;
+                power -= MachineConfig.solutionConsumptionPerOperationFrackingTower;
             } else {
                 warning = 1;
             }

--- a/src/main/java/com/hbm/tileentity/machine/oil/TileEntityMachineFrackingTower.java
+++ b/src/main/java/com/hbm/tileentity/machine/oil/TileEntityMachineFrackingTower.java
@@ -103,13 +103,13 @@ public class TileEntityMachineFrackingTower extends TileEntityOilDrillBase {
 
                                 if (succNumber == 1) {
                                     int oilCollected = MachineConfig.oilPerDepositBlockMinFrackingTower + ((MachineConfig.oilPerDepositBlockMaxExtraFrackingTower > 0) ? world.rand.nextInt(MachineConfig.oilPerDepositBlockMaxExtraFrackingTower) : 0);
-                                    int gasCollected = MachineConfig.gasPerDepositBlockMinFrackingTower + ((MachineConfig.gasPerDepositBlockMaxExtraFrackingTower > 0) ? world.rand.nextInt(MachineConfig.oilPerDepositBlockMaxExtraFrackingTower) : 0);
+                                    int gasCollected = MachineConfig.gasPerDepositBlockMinFrackingTower + ((MachineConfig.gasPerDepositBlockMaxExtraFrackingTower > 0) ? world.rand.nextInt(MachineConfig.gasPerDepositBlockMaxExtraFrackingTower) : 0);
 
                                     this.tanks[0].fill(new FluidStack(tankTypes[0], oilCollected), true);
                                     this.tanks[1].fill(new FluidStack(tankTypes[1], gasCollected), true);
                                 } else {
                                     int oilCollected = MachineConfig.oilPerBedrockDepositBlockMinFrackingTower + ((MachineConfig.oilPerBedrockDepositBlockMaxExtraFrackingTower > 0) ? world.rand.nextInt(MachineConfig.oilPerDepositBlockMaxExtraFrackingTower) : 0);
-                                    int gasCollected = MachineConfig.gasPerBedrockDepositBlockMinFrackingTower + ((MachineConfig.gasPerBedrockDepositBlockMaxExtraFrackingTower > 0) ? world.rand.nextInt(MachineConfig.oilPerDepositBlockMaxExtraFrackingTower) : 0);
+                                    int gasCollected = MachineConfig.gasPerBedrockDepositBlockMinFrackingTower + ((MachineConfig.gasPerBedrockDepositBlockMaxExtraFrackingTower > 0) ? world.rand.nextInt(MachineConfig.gasPerDepositBlockMaxExtraFrackingTower) : 0);
 
                                     this.tanks[0].fill(new FluidStack(tankTypes[0], oilCollected), true);
                                     this.tanks[1].fill(new FluidStack(tankTypes[1], gasCollected), true);

--- a/src/main/java/com/hbm/tileentity/machine/oil/TileEntityMachineOilWell.java
+++ b/src/main/java/com/hbm/tileentity/machine/oil/TileEntityMachineOilWell.java
@@ -104,7 +104,7 @@ public class TileEntityMachineOilWell extends TileEntityOilDrillBase {
 							if(succ(pos.getX(), i, pos.getZ()) == 1) {
 
 								int oilCollected = MachineConfig.oilPerDepositBlockMinDerrick + ((MachineConfig.oilPerDepositBlockMaxExtraDerrick > 0) ? world.rand.nextInt(MachineConfig.oilPerDepositBlockMaxExtraDerrick) : 0);
-								int gasCollected = MachineConfig.gasPerDepositBlockMinDerrick + ((MachineConfig.gasPerDepositBlockMaxExtraDerrick > 0) ? world.rand.nextInt(MachineConfig.oilPerDepositBlockMaxExtraDerrick) : 0);
+								int gasCollected = MachineConfig.gasPerDepositBlockMinDerrick + ((MachineConfig.gasPerDepositBlockMaxExtraDerrick > 0) ? world.rand.nextInt(MachineConfig.gasPerDepositBlockMaxExtraDerrick) : 0);
 
 								this.tanks[0].fill(new FluidStack(tankTypes[0], oilCollected), true);
 								this.tanks[1].fill(new FluidStack(tankTypes[1], gasCollected), true);

--- a/src/main/java/com/hbm/tileentity/machine/oil/TileEntityMachineOilWell.java
+++ b/src/main/java/com/hbm/tileentity/machine/oil/TileEntityMachineOilWell.java
@@ -1,6 +1,7 @@
 package com.hbm.tileentity.machine.oil;
 
 import com.hbm.blocks.ModBlocks;
+import com.hbm.config.MachineConfig;
 import com.hbm.entity.particle.EntityGasFX;
 import com.hbm.explosion.ExplosionLarge;
 import com.hbm.forgefluid.FFUtils;
@@ -23,13 +24,6 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class TileEntityMachineOilWell extends TileEntityOilDrillBase {
-	
-	protected static int delay = 50;
-	protected static int consumption = 100;
-
-    protected static int oilPerDeposit = 500;
-    protected static int gasPerDepositMin = 100;
-    protected static int extraGasPerDepositMax = 401;
 
 	// private static final int[] slots_top = new int[] {1};
 	// private static final int[] slots_bottom = new int[] {2, 0};
@@ -47,7 +41,7 @@ public class TileEntityMachineOilWell extends TileEntityOilDrillBase {
 	@SuppressWarnings("deprecation")
 	@Override
 	public void update() {
-		int timer = delay;
+		int timer = MachineConfig.delayPerOperationDerrick;
 
 		age++;
 		age2++;
@@ -74,7 +68,7 @@ public class TileEntityMachineOilWell extends TileEntityOilDrillBase {
 			}
 			power = Library.chargeTEFromItems(inventory, 0, power, getMaxPower());
 
-			if(power >= 100 && !(tank0Amount >= tanks[0].getCapacity() || tank1Amount >= tanks[1].getCapacity())) {
+			if(power >= MachineConfig.powerConsumptionPerOperationDerrick && !(tank0Amount >= tanks[0].getCapacity() || tank1Amount >= tanks[1].getCapacity())) {
 
 				// operation start
 
@@ -109,8 +103,11 @@ public class TileEntityMachineOilWell extends TileEntityOilDrillBase {
 						} else if(this.tanks[0].getFluidAmount() < this.tanks[0].getCapacity() && this.tanks[1].getFluidAmount() < this.tanks[1].getCapacity()) {
 							if(succ(pos.getX(), i, pos.getZ()) == 1) {
 
-								this.tanks[0].fill(new FluidStack(tankTypes[0], oilPerDeposit), true);
-								this.tanks[1].fill(new FluidStack(tankTypes[1], (gasPerDepositMin + world.rand.nextInt(extraGasPerDepositMax))), true);
+								int oilCollected = MachineConfig.oilPerDepositBlockMinDerrick + ((MachineConfig.oilPerDepositBlockMaxExtraDerrick > 0) ? world.rand.nextInt(MachineConfig.oilPerDepositBlockMaxExtraDerrick) : 0);
+								int gasCollected = MachineConfig.gasPerDepositBlockMinDerrick + ((MachineConfig.gasPerDepositBlockMaxExtraDerrick > 0) ? world.rand.nextInt(MachineConfig.oilPerDepositBlockMaxExtraDerrick) : 0);
+
+								this.tanks[0].fill(new FluidStack(tankTypes[0], oilCollected), true);
+								this.tanks[1].fill(new FluidStack(tankTypes[1], gasCollected), true);
 								needsUpdate = true;
 
 								ExplosionLarge.spawnOilSpills(world, pos.getX() + 0.5F, pos.getY() + 5.5F, pos.getZ() + 0.5F, 3);
@@ -132,7 +129,7 @@ public class TileEntityMachineOilWell extends TileEntityOilDrillBase {
 
 				// operation end
 
-				power -= consumption;
+				power -= MachineConfig.powerConsumptionPerOperationDerrick;
 			} else {
 				warning = 1;
 			}

--- a/src/main/java/com/hbm/tileentity/machine/oil/TileEntityMachinePumpjack.java
+++ b/src/main/java/com/hbm/tileentity/machine/oil/TileEntityMachinePumpjack.java
@@ -126,7 +126,7 @@ public class TileEntityMachinePumpjack extends TileEntityOilDrillBase {
 							if(succ(pos.getX(), i, pos.getZ()) == 1) {
 
 								int oilCollected = MachineConfig.oilPerDepositBlockMinPumpjack + ((MachineConfig.oilPerDepositBlockMaxExtraPumpjack > 0) ? world.rand.nextInt(MachineConfig.oilPerDepositBlockMaxExtraPumpjack) : 0);
-								int gasCollected = MachineConfig.gasPerDepositBlockMinPumpjack + ((MachineConfig.gasPerDepositBlockMaxExtraPumpjack > 0) ? world.rand.nextInt(MachineConfig.oilPerDepositBlockMaxExtraPumpjack) : 0);
+								int gasCollected = MachineConfig.gasPerDepositBlockMinPumpjack + ((MachineConfig.gasPerDepositBlockMaxExtraPumpjack > 0) ? world.rand.nextInt(MachineConfig.gasPerDepositBlockMaxExtraPumpjack) : 0);
 
 								this.tanks[0].fill(new FluidStack(tankTypes[0], oilCollected), true);
 								this.tanks[1].fill(new FluidStack(tankTypes[1], gasCollected), true);

--- a/src/main/java/com/hbm/tileentity/machine/oil/TileEntityMachinePumpjack.java
+++ b/src/main/java/com/hbm/tileentity/machine/oil/TileEntityMachinePumpjack.java
@@ -3,6 +3,7 @@ package com.hbm.tileentity.machine.oil;
 import com.hbm.blocks.BlockDummyable;
 import com.hbm.blocks.ModBlocks;
 import com.hbm.blocks.machine.MachinePumpjack;
+import com.hbm.config.MachineConfig;
 import com.hbm.entity.particle.EntityGasFX;
 import com.hbm.forgefluid.FFUtils;
 import com.hbm.items.ModItems;
@@ -29,13 +30,6 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class TileEntityMachinePumpjack extends TileEntityOilDrillBase {
-
-	protected static int delay = 25;
-	protected static int consumption = 200;
-
-	protected static int oilPerDeposit = 650;
-    protected static int gasPerDepositMin = 110;
-    protected static int extraGasPerDepositMax = 401;
 
 	public boolean isProgressing;
 	public float rotation;
@@ -69,7 +63,7 @@ public class TileEntityMachinePumpjack extends TileEntityOilDrillBase {
 	@SuppressWarnings("deprecation")
 	@Override
 	public void update() {
-		int timer = delay;
+		int timer = MachineConfig.delayPerOperationPumpjack;
 		prevRotation = rotation;
 		age++;
 		age2++;
@@ -96,7 +90,7 @@ public class TileEntityMachinePumpjack extends TileEntityOilDrillBase {
 			}
 			power = Library.chargeTEFromItems(inventory, 0, power, getMaxPower());
 
-			if(power >= 100 && !(tank0Amount >= tanks[0].getCapacity() || tank1Amount >= tanks[1].getCapacity())) {
+			if(power >= MachineConfig.powerConsumptionPerOperationPumpjack && !(tank0Amount >= tanks[0].getCapacity() || tank1Amount >= tanks[1].getCapacity())) {
 
 				// operation start
 
@@ -131,8 +125,11 @@ public class TileEntityMachinePumpjack extends TileEntityOilDrillBase {
 						} else if(this.tanks[0].getFluidAmount() < this.tanks[0].getCapacity() && this.tanks[1].getFluidAmount() < this.tanks[1].getCapacity()) {
 							if(succ(pos.getX(), i, pos.getZ()) == 1) {
 
-								this.tanks[0].fill(new FluidStack(tankTypes[0], oilPerDeposit), true);
-								this.tanks[1].fill(new FluidStack(tankTypes[1], (gasPerDepositMin + world.rand.nextInt(extraGasPerDepositMax))), true);
+								int oilCollected = MachineConfig.oilPerDepositBlockMinPumpjack + ((MachineConfig.oilPerDepositBlockMaxExtraPumpjack > 0) ? world.rand.nextInt(MachineConfig.oilPerDepositBlockMaxExtraPumpjack) : 0);
+								int gasCollected = MachineConfig.gasPerDepositBlockMinPumpjack + ((MachineConfig.gasPerDepositBlockMaxExtraPumpjack > 0) ? world.rand.nextInt(MachineConfig.oilPerDepositBlockMaxExtraPumpjack) : 0);
+
+								this.tanks[0].fill(new FluidStack(tankTypes[0], oilCollected), true);
+								this.tanks[1].fill(new FluidStack(tankTypes[1], gasCollected), true);
 								needsUpdate = true;
 
 								break;
@@ -151,7 +148,7 @@ public class TileEntityMachinePumpjack extends TileEntityOilDrillBase {
 
 				// operation end
 
-				power -= consumption;
+				power -= MachineConfig.powerConsumptionPerOperationPumpjack;
 			} else {
 				warning = 1;
 			}


### PR DESCRIPTION
Change highlights:

- Closes #148, adding config options for oil harvesting machines.

Tested in creative world with oil derrick; was able to harvest 2000mB of crude per block after setting config value. List of config values and defaults are below:

```
    # Controls how much delay between extraction or drilling operations for Oil Derricks
    I:9.00_delayPerOperationDerrick=50

    # Controls how much power is consumed per operation for Oil Derricks
    I:9.01_powerConsumptionPerOperationDerrick=100

    # Controls how much crude oil at minimum is extracted per deposit block for Oil Derricks
    I:9.02_oilPerDepositBlockMinDerrick=500

    # Controls how much extra crude oil can be extracted per deposit block for Oil Derricks
    I:9.03_oilPerDepositBlockMaxExtraDerrick=0

    # Controls how much natrual gas at minimum is extracted per deposit block for Oil Derricks
    I:9.04_gasPerDepositBlockMinDerrick=100

    # Controls how much extra natrual gas can be extracted per deposit block for Oil Derricks
    I:9.05_gasPerDepositBlockMaxExtraDerrick=401

    # Controls how much delay between extraction or drilling operations for Pumpjacks
    I:9.06_delayPerOperationPumpjack=25

    # Controls how much power is consumed per operation for Pumpjacks
    I:9.07_powerConsumptionPerOperationPumpjack=200

    # Controls how much crude oil at minimum is extracted per deposit block for Pumpjacks
    I:9.08_oilPerDepositBlockMinPumpjack=650

    # Controls how much extra crude oil can be extracted per deposit block for Pumpjacks
    I:9.09_oilPerDepositBlockMaxExtraPumpjack=0

    # Controls how much natrual gas at minimum is extracted per deposit block for Pumpjacks
    I:9.10_gasPerDepositBlockMinPumpjack=110

    # Controls how much extra natrual gas can be extracted per deposit block for Pumpjacks
    I:9.11_gasPerDepositBlockMaxExtraPumpjack=401

    # Controls how much delay between extraction or drilling operations for Fracking towers
    I:9.12_delayPerOperationFrackingTower=20

    # Controls how much power is consumed per operation for Fracking towers
    I:9.13_powerConsumptionPerOperationFrackingTower=5000

    # Controls how much fracking solution is consumed per operation for Fracking towers
    I:9.14_solutionConsumptionPerOperationFrackingTower=10

    # Controls how far in blocks around a Fracking tower the world is affected during operation
    I:9.15_worldDestructionRangeFrackingTower=32

    # Controls how much crude oil at minimum is extracted per deposit block for Fracking towers
    I:9.16_oilPerDepositBlockMinFrackingTower=1000

    # Controls how much extra crude oil can be extracted per deposit block for Fracking towers
    I:9.17_oilPerDepositBlockMaxExtraFrackingTower=0

    # Controls how much natrual gas at minimum is extracted per deposit block for Fracking towers
    I:9.18_gasPerDepositBlockMinFrackingTower=200

    # Controls how much extra natrual gas can be extracted per deposit block for Fracking towers
    I:9.19_gasPerDepositBlockMaxExtraFrackingTower=401

    # Controls how much crude oil at minimum is extracted per bedrock deposit block for Fracking towers
    I:9.20_oilPerBedrockDepositBlockMinFrackingTower=100

    # Controls how much extra crude oil can be extracted per bedrock deposit block for Fracking towers
    I:9.21_oilPerBedrockDepositBlockMaxExtraFrackingTower=0

    # Controls how much natrual gas at minimum is extracted per bedrock deposit block for Fracking towers
    I:9.22_gasPerBedrockDepositBlockMinFrackingTower=10

    # Controls how much extra natrual gas can be extracted per bedrock deposit block for Fracking towers
    I:9.23_gasPerBedrockDepositBlockMaxExtraFrackingTower=50
```
