### PR TITLE
Add fluid identifier control to Crystallizer

### DIFF
--- a/src/main/java/com/hbm/inventory/container/ContainerCrystallizer.java
+++ b/src/main/java/com/hbm/inventory/container/ContainerCrystallizer.java
@@ -13,10 +13,10 @@ import net.minecraftforge.items.SlotItemHandler;
 
 public class ContainerCrystallizer extends Container {
 
-	private TileEntityMachineCrystallizer diFurnace;
+	private TileEntityMachineCrystallizer machineCrystallizer;
 
 	public ContainerCrystallizer(InventoryPlayer invPlayer, TileEntityMachineCrystallizer tedf) {
-		diFurnace = tedf;
+		machineCrystallizer = tedf;
 
 		this.addSlotToContainer(new SlotItemHandler(tedf.inventory, TileEntityMachineCrystallizer.CrystallizerSlot.INPUT.get(), 62, 45));
 		this.addSlotToContainer(new SlotItemHandler(tedf.inventory, TileEntityMachineCrystallizer.CrystallizerSlot.BATTERY.get(), 152, 72));
@@ -25,6 +25,7 @@ public class ContainerCrystallizer extends Container {
 		this.addSlotToContainer(new SlotMachineOutput(tedf.inventory, TileEntityMachineCrystallizer.CrystallizerSlot.FLUID_OUTPUT.get(), 17, 54));
 		this.addSlotToContainer(new SlotUpgrade(tedf.inventory, TileEntityMachineCrystallizer.CrystallizerSlot.UPGRADE_0.get(), 80, 18));
 		this.addSlotToContainer(new SlotUpgrade(tedf.inventory, TileEntityMachineCrystallizer.CrystallizerSlot.UPGRADE_1.get(), 98, 18));
+		this.addSlotToContainer(new SlotItemHandler(tedf.inventory, TileEntityMachineCrystallizer.CrystallizerSlot.FLUID_IDENTIFIER.get(), 35, 72));
 
 		for(int i = 0; i < 3; i++)
 		{
@@ -51,8 +52,8 @@ public class ContainerCrystallizer extends Container {
 			ItemStack var5 = var4.getStack();
 			var3 = var5.copy();
 			
-            if (par2 <= diFurnace.inventory.getSlots() - 1) {
-				if (!this.mergeItemStack(var5, diFurnace.inventory.getSlots(), this.inventorySlots.size(), true))
+            if (par2 <= machineCrystallizer.inventory.getSlots() - 1) {
+				if (!this.mergeItemStack(var5, machineCrystallizer.inventory.getSlots(), this.inventorySlots.size(), true))
 				{
 					return ItemStack.EMPTY;
 				}
@@ -79,6 +80,6 @@ public class ContainerCrystallizer extends Container {
 	
 	@Override
 	public boolean canInteractWith(EntityPlayer player) {
-		return diFurnace.isUseableByPlayer(player);
+		return machineCrystallizer.isUseableByPlayer(player);
 	}
 }

--- a/src/main/java/com/hbm/inventory/container/ContainerCrystallizer.java
+++ b/src/main/java/com/hbm/inventory/container/ContainerCrystallizer.java
@@ -18,14 +18,14 @@ public class ContainerCrystallizer extends Container {
 	public ContainerCrystallizer(InventoryPlayer invPlayer, TileEntityMachineCrystallizer tedf) {
 		machineCrystallizer = tedf;
 
-		this.addSlotToContainer(new SlotItemHandler(tedf.inventory, TileEntityMachineCrystallizer.CrystallizerSlot.INPUT.get(), 62, 45));
-		this.addSlotToContainer(new SlotItemHandler(tedf.inventory, TileEntityMachineCrystallizer.CrystallizerSlot.BATTERY.get(), 152, 72));
-		this.addSlotToContainer(new SlotMachineOutput(tedf.inventory, TileEntityMachineCrystallizer.CrystallizerSlot.OUTPUT.get(), 113, 45));
-		this.addSlotToContainer(new SlotItemHandler(tedf.inventory, TileEntityMachineCrystallizer.CrystallizerSlot.FLUID_INPUT.get(), 17, 18));
-		this.addSlotToContainer(new SlotMachineOutput(tedf.inventory, TileEntityMachineCrystallizer.CrystallizerSlot.FLUID_OUTPUT.get(), 17, 54));
-		this.addSlotToContainer(new SlotUpgrade(tedf.inventory, TileEntityMachineCrystallizer.CrystallizerSlot.UPGRADE_0.get(), 80, 18));
-		this.addSlotToContainer(new SlotUpgrade(tedf.inventory, TileEntityMachineCrystallizer.CrystallizerSlot.UPGRADE_1.get(), 98, 18));
-		this.addSlotToContainer(new SlotItemHandler(tedf.inventory, TileEntityMachineCrystallizer.CrystallizerSlot.FLUID_IDENTIFIER.get(), 35, 72));
+		this.addSlotToContainer(new SlotItemHandler(tedf.inventory, TileEntityMachineCrystallizer.SLOT_INPUT, 62, 45));
+		this.addSlotToContainer(new SlotItemHandler(tedf.inventory, TileEntityMachineCrystallizer.SLOT_BATTERY, 152, 72));
+		this.addSlotToContainer(new SlotMachineOutput(tedf.inventory, TileEntityMachineCrystallizer.SLOT_OUTPUT, 113, 45));
+		this.addSlotToContainer(new SlotItemHandler(tedf.inventory, TileEntityMachineCrystallizer.SLOT_FLUID_INPUT, 17, 18));
+		this.addSlotToContainer(new SlotMachineOutput(tedf.inventory, TileEntityMachineCrystallizer.SLOT_FLUID_OUTPUT, 17, 54));
+		this.addSlotToContainer(new SlotUpgrade(tedf.inventory, TileEntityMachineCrystallizer.SLOT_UPGRADE_0, 80, 18));
+		this.addSlotToContainer(new SlotUpgrade(tedf.inventory, TileEntityMachineCrystallizer.SLOT_UPGRADE_1, 98, 18));
+		this.addSlotToContainer(new SlotItemHandler(tedf.inventory, TileEntityMachineCrystallizer.SLOT_FLUID_IDENTIFIER, 35, 72));
 
 		for(int i = 0; i < 3; i++)
 		{

--- a/src/main/java/com/hbm/inventory/container/ContainerCrystallizer.java
+++ b/src/main/java/com/hbm/inventory/container/ContainerCrystallizer.java
@@ -18,13 +18,13 @@ public class ContainerCrystallizer extends Container {
 	public ContainerCrystallizer(InventoryPlayer invPlayer, TileEntityMachineCrystallizer tedf) {
 		diFurnace = tedf;
 
-		this.addSlotToContainer(new SlotItemHandler(tedf.inventory, 0, 62, 45));
-		this.addSlotToContainer(new SlotItemHandler(tedf.inventory, 1, 152, 72));
-		this.addSlotToContainer(new SlotMachineOutput(tedf.inventory, 2, 113, 45));
-		this.addSlotToContainer(new SlotItemHandler(tedf.inventory, 3, 17, 18));
-		this.addSlotToContainer(new SlotMachineOutput(tedf.inventory, 4, 17, 54));
-		this.addSlotToContainer(new SlotUpgrade(tedf.inventory, 5, 80, 18));
-		this.addSlotToContainer(new SlotUpgrade(tedf.inventory, 6, 98, 18));
+		this.addSlotToContainer(new SlotItemHandler(tedf.inventory, TileEntityMachineCrystallizer.CrystallizerSlot.INPUT.get(), 62, 45));
+		this.addSlotToContainer(new SlotItemHandler(tedf.inventory, TileEntityMachineCrystallizer.CrystallizerSlot.BATTERY.get(), 152, 72));
+		this.addSlotToContainer(new SlotMachineOutput(tedf.inventory, TileEntityMachineCrystallizer.CrystallizerSlot.OUTPUT.get(), 113, 45));
+		this.addSlotToContainer(new SlotItemHandler(tedf.inventory, TileEntityMachineCrystallizer.CrystallizerSlot.FLUID_INPUT.get(), 17, 18));
+		this.addSlotToContainer(new SlotMachineOutput(tedf.inventory, TileEntityMachineCrystallizer.CrystallizerSlot.FLUID_OUTPUT.get(), 17, 54));
+		this.addSlotToContainer(new SlotUpgrade(tedf.inventory, TileEntityMachineCrystallizer.CrystallizerSlot.UPGRADE_0.get(), 80, 18));
+		this.addSlotToContainer(new SlotUpgrade(tedf.inventory, TileEntityMachineCrystallizer.CrystallizerSlot.UPGRADE_1.get(), 98, 18));
 
 		for(int i = 0; i < 3; i++)
 		{

--- a/src/main/java/com/hbm/lib/Library.java
+++ b/src/main/java/com/hbm/lib/Library.java
@@ -225,28 +225,36 @@ public class Library {
 
 	// Drillgon200: Just realized I copied the wrong method. God dang it.
 	// It works though. Not sure why, but it works.
-	public static long chargeTEFromItems(IItemHandlerModifiable inventory, int index, long power, long maxPower) {
-		if(inventory.getStackInSlot(index).getItem() == ModItems.battery_creative)
+	/**
+	 * Handles charging of machine tile entities
+	 * @param inventory the inventory of the charging tile entity
+	 * @param slotIndex the slot index of the battery slot
+	 * @param power the current power level of the tile entity
+	 * @param maxPower the maximum power level that the tile entity can be charged to
+	 * @return the new power level of the tile entity
+	 */
+	public static long chargeTEFromItems(IItemHandlerModifiable inventory, int slotIndex, long power, long maxPower) {
+		if(inventory.getStackInSlot(slotIndex).getItem() == ModItems.battery_creative)
 		{
 			return maxPower;
 		}
 		
-		if(inventory.getStackInSlot(index).getItem() == ModItems.fusion_core_infinite)
+		if(inventory.getStackInSlot(slotIndex).getItem() == ModItems.fusion_core_infinite)
 		{
 			return maxPower;
 		}
 		
-		if(inventory.getStackInSlot(index).getItem() instanceof IBatteryItem) {
+		if(inventory.getStackInSlot(slotIndex).getItem() instanceof IBatteryItem) {
 			
-			IBatteryItem battery = (IBatteryItem) inventory.getStackInSlot(index).getItem();
+			IBatteryItem battery = (IBatteryItem) inventory.getStackInSlot(slotIndex).getItem();
 
-			long batCharge = battery.getCharge(inventory.getStackInSlot(index));
+			long batCharge = battery.getCharge(inventory.getStackInSlot(slotIndex));
 			long batRate = battery.getDischargeRate();
 			
 			//in hHe
 			long toDischarge = Math.min(Math.min((maxPower - power), batRate), batCharge);
 			
-			battery.dischargeBattery(inventory.getStackInSlot(index), toDischarge);
+			battery.dischargeBattery(inventory.getStackInSlot(slotIndex), toDischarge);
 			power += toDischarge;
 		}
 		

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachineCrystallizer.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachineCrystallizer.java
@@ -23,6 +23,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ITickable;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
@@ -100,8 +101,8 @@ public class TileEntityMachineCrystallizer extends TileEntityMachineBase impleme
 		return "container.crystallizer";
 	}
 
-	private void updateConnections() {
-
+	private void getPowerInit() {
+		// Ore Acidizers have two power ports on the left and right sides, when facing the front of the machine
 		ForgeDirection dir = ForgeDirection.getOrientation(this.getBlockMetadata() - BlockDummyable.offset);
 
 		if(dir == ForgeDirection.NORTH || dir == ForgeDirection.SOUTH) {
@@ -113,11 +114,24 @@ public class TileEntityMachineCrystallizer extends TileEntityMachineBase impleme
 		}
 	}
 
+	private void fillFluidInit(FluidTank type) {
+		// Ore Acidizers have 4 fluid ports, each one at the bottom middle of all horizontal sides
+		fillFluid(pos.getX() + 0, pos.getY(), pos.getZ() + 2, type);
+		fillFluid(pos.getX() + 0, pos.getY(), pos.getZ() - 2, type);
+		fillFluid(pos.getX() + 2, pos.getY(), pos.getZ() + 0, type);
+		fillFluid(pos.getX() - 2, pos.getY(), pos.getZ() + 0, type);
+	}
+
+	private void fillFluid(int x, int y, int z, FluidTank type) {
+		FFUtils.fillFluid(this, type, world, new BlockPos(x, y, z), 10239000);
+	}
+
 	@Override
 	public void update() {
 		if(!world.isRemote) {
 
-			this.updateConnections();
+			this.getPowerInit();
+			this.fillFluidInit(tank);
 
 			// Prevent crash from old ore acidizers that have incorrect num of slots in inv
 			if (inventory.getSlots() < CrystallizerSlot.values().length) {
@@ -377,6 +391,8 @@ public class TileEntityMachineCrystallizer extends TileEntityMachineBase impleme
 			return new int[] { CrystallizerSlot.INPUT.get(), CrystallizerSlot.OUTPUT.get() };
 		}
 	}
+
+
 
 	@Override
 	public AxisAlignedBB getRenderBoundingBox() {

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachineCrystallizer.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachineCrystallizer.java
@@ -119,6 +119,11 @@ public class TileEntityMachineCrystallizer extends TileEntityMachineBase impleme
 
 			this.updateConnections();
 
+			// Prevent crash from old ore acidizers that have incorrect num of slots in inv
+			if (inventory.getSlots() < CrystallizerSlot.values().length) {
+				inventory.setSize(CrystallizerSlot.values().length);
+			}
+
 			// Allow swapping of input fluid type using fluid identifier
 			if(inventory.getStackInSlot(CrystallizerSlot.FLUID_IDENTIFIER.get()).getItem() == ModItems.forge_fluid_identifier){
 				Fluid fluidFromIdentifier = ItemForgeFluidIdentifier.getType(inventory.getStackInSlot(CrystallizerSlot.FLUID_IDENTIFIER.get()));
@@ -446,9 +451,7 @@ public class TileEntityMachineCrystallizer extends TileEntityMachineBase impleme
 
 	@Override
 	public <T> T getCapability(Capability<T> capability, EnumFacing facing) {
-		if(capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY){
-			return CapabilityItemHandler.ITEM_HANDLER_CAPABILITY.cast(inventory);
-		} else if(capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY){
+		if(capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY){
 			return CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY.cast(this);
 		} else {
 			return super.getCapability(capability, facing);
@@ -457,9 +460,7 @@ public class TileEntityMachineCrystallizer extends TileEntityMachineBase impleme
 
 	@Override
 	public boolean hasCapability(Capability<?> capability, EnumFacing facing) {
-		if(capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
-			return true;
-		} else if(capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
+		if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
 			return true;
 		} else {
 			return super.hasCapability(capability, facing);

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachineCrystallizer.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachineCrystallizer.java
@@ -62,7 +62,7 @@ public class TileEntityMachineCrystallizer extends TileEntityMachineBase impleme
 	public FluidTank tank;
 
 	public TileEntityMachineCrystallizer() {
-		super(8);
+		super(0);
 
 		inventory = new ItemStackHandler(8) {
 

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachineCrystallizer.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachineCrystallizer.java
@@ -69,7 +69,7 @@ public class TileEntityMachineCrystallizer extends TileEntityMachineBase impleme
 	public FluidTank tank;
 
 	public TileEntityMachineCrystallizer() {
-		super();
+		super(CrystallizerSlot.values().length);
 
 		inventory = new ItemStackHandler(CrystallizerSlot.values().length) {
 


### PR DESCRIPTION
Change highlights:

- Added fluid identifier slot to Crystallizer to allow swapping of fluid types if tank is empty.
- Improved readability of Crystallizer slot interaction, moved to slot index constants.
- Miscellaneous clean up of associated classes.