### PR TITLE
"Bandaid" Wacky Overworld Bedrock oreGen 

### DIFF
--- a/src/main/java/com/hbm/config/BedrockOreJsonConfig.java
+++ b/src/main/java/com/hbm/config/BedrockOreJsonConfig.java
@@ -45,14 +45,34 @@ public class BedrockOreJsonConfig {
 
 	public static void setDefaults() {
 		addEntry(0, 30, Arrays.asList(
-			"orePlutonium", 
-			"oreQuartz", 
-			"oreInfernalCoal", 
-			"oreRedPhosphorus", 
-			"oreSchrabidium", 
-			"oreNeodymium", 
-			"oreNitanium"
-		), false);
+			"oreCoal", 
+			"oreIron", 
+			"oreGold",
+			"oreRedstone",
+			"oreLapis",
+			"oreDiamond",
+			"oreEmerald",
+			"oreLignite",
+			"oreSulfur",
+			"oreSaltpeter",
+			"oreAsbestos",
+			"oreFluorite",
+			"oreCinnabar",
+			"oreCopper",
+			"oreAluminum",
+			"oreLead",
+			"oreLithium",
+			"oreBeryllium",
+			"oreTitanium",
+			"oreTungsten",
+			"oreCobalt",
+			"oreRareEarth",
+			"oreThorium",
+			"oreUranium",
+			"oreZirconium",
+			"oreVolcanic",
+			"oreBorax"
+		), true);
 		addEntry(-1, 60, Arrays.asList(
 			"orePlutonium", 
 			"oreQuartz", 


### PR DESCRIPTION
Reformated overworld default to be a whitelist and contain all ores found in the overworld with the base game and mod
- **Set default mode for Overworld whitelist to true** 
- Rewritten to include all BG overworld ores and Overworld NTM ores
- **Note:** Excludes "Special" material chain (Reiium, Australium, unobtainium, etc.); Include these values if they are supposed to be there initially; did this due to uncertainty if it was intended or not.

**I went over all of them one by one but please double check for anything that may be missing.**