### PR TITLE
Rebalance Osmiridium refining

### DIFF
--- a/src/main/java/com/hbm/inventory/CentrifugeRecipes.java
+++ b/src/main/java/com/hbm/inventory/CentrifugeRecipes.java
@@ -209,7 +209,7 @@ public class CentrifugeRecipes {
 				new ItemStack(Blocks.GRAVEL, 1) });
 
 		recipes.put(new ComparableStack(ModItems.powder_tektite), new ItemStack[] {
-				new ItemStack(ModItems.powder_paleogenite_tiny, 1),
+				new ItemStack(ModItems.powder_paleogenite_tiny, 2),
 				new ItemStack(ModItems.powder_meteorite_tiny, 1),
 				new ItemStack(ModItems.powder_meteorite_tiny, 1),
 				new ItemStack(ModItems.dust, 6) });

--- a/src/main/java/com/hbm/inventory/MachineRecipes.java
+++ b/src/main/java/com/hbm/inventory/MachineRecipes.java
@@ -137,7 +137,7 @@ public class MachineRecipes {
 		else if(fluid == ModForgeFluids.nitan)
 			return 500;
 		else if(fluid == ModForgeFluids.liquid_osmiridium)
-			return 2000;
+			return 1000; //whose idea was 2000 heck nah
 		else
 			return 0;
 	}

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachineSatDock.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachineSatDock.java
@@ -121,7 +121,7 @@ public class TileEntityMachineSatDock extends TileEntity implements ITickable {
 					}
 				}
 				if(sat != null && sat instanceof SatelliteHorizons) {
-
+					int delay = 10 * 30 * 1000; //5min due to tektite rarity, probably really bad code position
 					SatelliteHorizons gerald = (SatelliteHorizons)sat;
 
 					if(gerald.lastOp + delay < System.currentTimeMillis()) {

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachineSatDock.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachineSatDock.java
@@ -121,7 +121,7 @@ public class TileEntityMachineSatDock extends TileEntity implements ITickable {
 					}
 				}
 				if(sat != null && sat instanceof SatelliteHorizons) {
-					int delay = 10 * 30 * 1000; //5min due to tektite rarity, probably really bad code position
+					delay = 10 * 30 * 1000; //5min due to tektite rarity, was right a few commits ago
 					SatelliteHorizons gerald = (SatelliteHorizons)sat;
 
 					if(gerald.lastOp + delay < System.currentTimeMillis()) {


### PR DESCRIPTION
I did some math with the osmiridium refining. it takes approximately 24 hours to get enough tektite to make one osmiridium ingot with the current balance for the recipes. tht means it would take 48 days of continous runtime to make an electronium energy storage block! what's changed here:

1. changed Gerald's cooldown for the mining pad to 5 minutes instead of 10
2. make tektite give 2 small paleogenite powder instead of 1 when centrifuged
3. halved gas centrifuge osmiridic solution requirement (16000mb -> 8000mb)