### PR TITLE
allow crt add Assembler Recipe use ore dict

### DIFF
--- a/src/main/java/com/hbm/handler/crt/Anvil.java
+++ b/src/main/java/com/hbm/handler/crt/Anvil.java
@@ -1,0 +1,76 @@
+package com.hbm.handler.crt;
+
+
+import com.hbm.inventory.RecipesCommon;
+import crafttweaker.CraftTweakerAPI;
+import crafttweaker.IAction;
+import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.item.IItemStack;
+import crafttweaker.api.minecraft.CraftTweakerMC;
+import net.minecraft.item.ItemStack;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+
+import com.hbm.inventory.AnvilRecipes;
+
+import java.util.Arrays;
+
+@ZenRegister
+@ZenClass("mods.ntm.Anvil")
+public class Anvil {
+	private static class ActionAddRecipe implements IAction {
+
+		/**
+		 * Executes what the action is supposed to do. This method can be called
+		 * again if undo() has been called in between.
+		 */
+		@Override
+		public void apply() {
+
+		}
+
+		/**
+		 * Describes, in a single human-readable sentence, what this specific action
+		 * is doing. Used in logging messages, lists, ...
+		 * <p>
+		 * Try to be as descriptive as possible without being too verbose.
+		 * <p>
+		 * Examples: - Adding Peach planks to the woodPlanks ore dictionary entry -
+		 * Removing a recipe for Iron Ore
+		 *
+		 * @return the description of this action
+		 */
+		@Override
+		public String describe() {
+			return "add anvil Recipe";
+		}
+	}
+
+	public static class ActionRemoveRecipe implements IAction{
+		private ItemStack[] output;
+
+		public ActionRemoveRecipe(IItemStack[] output){
+			this.output = CraftTweakerMC.getItemStacks(output);
+		}
+		@Override
+		public void apply(){
+			if(this.output == null ){
+				CraftTweakerAPI.logError("ERROR Anvil output item can not be an empty/air stack!");
+				return;
+			}
+			AnvilRecipes.removeConstructionRecipe(this.output);
+		}
+		@Override
+		public String describe(){
+			return "Removing NTM Anvil recipe for output "+ Arrays.toString(this.output);
+		}
+	}
+
+
+	@ZenMethod
+	public static void removeRecipe(IItemStack[] output){
+		CraftTweakerAPI.logInfo("start remove recipe"+ Arrays.toString(output));
+		NTMCraftTweaker.postInitActions.add(new Anvil.ActionRemoveRecipe(output));
+	}
+}

--- a/src/main/java/com/hbm/handler/crt/Anvil.java
+++ b/src/main/java/com/hbm/handler/crt/Anvil.java
@@ -93,23 +93,23 @@ public class Anvil {
 
 	@ZenMethod
 	public static void addRecipe(IItemStack[] output, IIngredient[] inputs, int tier){
-		CraftTweakerAPI.apply(new ActionAddRecipe(output, inputs, tier));
+		NTMCraftTweaker.postInitActions.add(new ActionAddRecipe(output, inputs, tier));
 	}
 
 	@ZenMethod
 	public static void addRecipe(IItemStack[] output, IIngredient inputs, int tier){
 		// inputs to array
-		CraftTweakerAPI.apply(new ActionAddRecipe(output, new IIngredient[]{inputs}, tier));
+		NTMCraftTweaker.postInitActions.add(new ActionAddRecipe(output, new IIngredient[]{inputs}, tier));
 	}
 
 	@ZenMethod
 	public static void addRecipe(IItemStack output,  IIngredient[] inputs, int tier){
-		CraftTweakerAPI.apply(new ActionAddRecipe(new IItemStack[]{output}, inputs, tier));
+		NTMCraftTweaker.postInitActions.add(new ActionAddRecipe(new IItemStack[]{output}, inputs, tier));
 	}
 
 	@ZenMethod
 	public static void addRecipe(IItemStack output, IIngredient inputs, int tier){
-		CraftTweakerAPI.apply(new ActionAddRecipe(new IItemStack[]{output}, new IIngredient[]{inputs}, tier));
+		NTMCraftTweaker.postInitActions.add(new ActionAddRecipe(new IItemStack[]{output}, new IIngredient[]{inputs}, tier));
 	}
 
 	@ZenMethod

--- a/src/main/java/com/hbm/handler/crt/Assembler.java
+++ b/src/main/java/com/hbm/handler/crt/Assembler.java
@@ -57,27 +57,7 @@ public class Assembler {
 				CraftTweakerAPI.logError("ERROR Assembler recipe duraction must be >=1 not "+this.duration+"!");
 				return;
 			}
-			RecipesCommon.AStack[] compInputs = new RecipesCommon.AStack[this.inputs.length];
-			for(int i = 0; i < this.inputs.length; i++){
-				if(this.inputs[i] instanceof IOreDictEntry ){
-					compInputs[i] = new RecipesCommon.OreDictStack(((IOreDictEntry) this.inputs[i]).getName());
-				    continue;
-				}
-
-				if(this.inputs[i] instanceof IngredientStack){
-					IIngredient  ingredient = (IIngredient) this.inputs[i].getInternal();
-					if(ingredient instanceof IOreDictEntry){
-						compInputs[i] = new RecipesCommon.OreDictStack(((IOreDictEntry) ingredient).getName(), this.inputs[i].getAmount());
-						continue;
-					}
-				}
-				if(this.inputs[i] instanceof IItemStack){
-					compInputs[i] = new ComparableStack(CraftTweakerMC.getItemStack((IItemStack) this.inputs[i]));
-					continue;
-				}
-				CraftTweakerAPI.logError("ERROR Assembler Input "+this.inputs[i].toString() + " class "+this.inputs[i].getClass());
-				return;
-			}
+			RecipesCommon.AStack[] compInputs = NTMCraftTweaker.IIngredientsToAStack(this.inputs);
 			AssemblerRecipes.makeRecipe(new ComparableStack(this.output), compInputs, this.duration);
 		}
 		@Override

--- a/src/main/java/com/hbm/handler/crt/Assembler.java
+++ b/src/main/java/com/hbm/handler/crt/Assembler.java
@@ -92,7 +92,7 @@ public class Assembler {
 	}
 
 	@ZenMethod
-	public static void replaceRecipe(IItemStack output, IItemStack[] inputs, int duration){
+	public static void replaceRecipe(IItemStack output, IIngredient[] inputs, int duration){
 		NTMCraftTweaker.postInitActions.add(new ActionRemoveRecipe(output));
 		NTMCraftTweaker.postInitActions.add(new ActionAddRecipe(output, inputs, duration));
 	}

--- a/src/main/java/com/hbm/handler/crt/Assembler.java
+++ b/src/main/java/com/hbm/handler/crt/Assembler.java
@@ -1,33 +1,35 @@
 package com.hbm.handler.crt;
 
+import com.hbm.inventory.RecipesCommon;
 import crafttweaker.IAction;
 import crafttweaker.CraftTweakerAPI;
+import crafttweaker.api.item.IngredientStack;
 import crafttweaker.api.minecraft.CraftTweakerMC;
 import crafttweaker.api.item.IIngredient;
 import crafttweaker.api.item.IItemStack;
 import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.oredict.IOreDictEntry;
+import crafttweaker.api.oredict.IngredientOreDict;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
 import com.hbm.inventory.AssemblerRecipes;
 import com.hbm.inventory.RecipesCommon.ComparableStack;
 
-import net.minecraft.init.Blocks;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+
+import java.util.Arrays;
 
 @ZenRegister
 @ZenClass("mods.ntm.Assembler")
 public class Assembler {
 	
 	private static class ActionAddRecipe implements IAction{
-		private ItemStack[] inputs;
+		private IIngredient[] inputs;
 		private ItemStack output;
 		private int duration = 0;
-		public ActionAddRecipe(IItemStack output, IItemStack[] inputs, int duration){
-			this.inputs = new ItemStack[inputs.length];
-			for(int i = 0; i < inputs.length; i++)
-				this.inputs[i] = CraftTweakerMC.getItemStack(inputs[i]);
+		public ActionAddRecipe(IItemStack output, IIngredient[] inputs, int duration){
+			this.inputs = inputs;
 			this.output = CraftTweakerMC.getItemStack(output);
 			this.duration = duration;
 		}
@@ -41,8 +43,8 @@ public class Assembler {
 				CraftTweakerAPI.logError("ERROR Assembler recipe input item count must be <=12 not "+this.inputs.length+"!");
 				return;
 			}
-			for(ItemStack i: this.inputs){
-				if(i == null || i.isEmpty()){
+			for(IIngredient i: this.inputs){
+				if(i == null ){
 					CraftTweakerAPI.logError("ERROR Assembler recipe input items can not include an empty/air stack!");
 					return;
 				}
@@ -55,19 +57,37 @@ public class Assembler {
 				CraftTweakerAPI.logError("ERROR Assembler recipe duraction must be >=1 not "+this.duration+"!");
 				return;
 			}
-			ComparableStack[] compInputs = new ComparableStack[this.inputs.length];
-			for(int i = 0; i < this.inputs.length; i++)
-				compInputs[i] = new ComparableStack(this.inputs[i]);
+			RecipesCommon.AStack[] compInputs = new RecipesCommon.AStack[this.inputs.length];
+			for(int i = 0; i < this.inputs.length; i++){
+				if(this.inputs[i] instanceof IOreDictEntry ){
+					compInputs[i] = new RecipesCommon.OreDictStack(((IOreDictEntry) this.inputs[i]).getName());
+				    continue;
+				}
+
+				if(this.inputs[i] instanceof IngredientStack){
+					IIngredient  ingredient = (IIngredient) this.inputs[i].getInternal();
+					if(ingredient instanceof IOreDictEntry){
+						compInputs[i] = new RecipesCommon.OreDictStack(((IOreDictEntry) ingredient).getName(), this.inputs[i].getAmount());
+						continue;
+					}
+				}
+				if(this.inputs[i] instanceof IItemStack){
+					compInputs[i] = new ComparableStack(CraftTweakerMC.getItemStack((IItemStack) this.inputs[i]));
+					continue;
+				}
+				CraftTweakerAPI.logError("ERROR Assembler Input "+this.inputs[i].toString() + " class "+this.inputs[i].getClass());
+				return;
+			}
 			AssemblerRecipes.makeRecipe(new ComparableStack(this.output), compInputs, this.duration);
 		}
 		@Override
 		public String describe(){
-			return "Adding NTM assembler recipe ("+this.inputs+" + "+this.duration+" ticks -> "+this.output+")";
+			return "Adding NTM assembler recipe ("+ Arrays.toString(this.inputs) +" + "+this.duration+" ticks -> "+this.output+")";
 		}
 	}
 
 	@ZenMethod
-	public static void addRecipe(IItemStack output, IItemStack[] inputs, int duration){
+	public static void addRecipe(IItemStack output, IIngredient[] inputs, int duration){
 		CraftTweakerAPI.apply(new ActionAddRecipe(output, inputs, duration));
 	}
 

--- a/src/main/java/com/hbm/handler/crt/BlastFurnace.java
+++ b/src/main/java/com/hbm/handler/crt/BlastFurnace.java
@@ -1,5 +1,6 @@
 package com.hbm.handler.crt;
 
+import com.hbm.inventory.RecipesCommon;
 import crafttweaker.IAction;
 import crafttweaker.CraftTweakerAPI;
 import crafttweaker.api.minecraft.CraftTweakerMC;
@@ -12,8 +13,6 @@ import stanhebben.zenscript.annotations.ZenMethod;
 import com.hbm.inventory.RecipesCommon.ComparableStack;
 import com.hbm.inventory.DiFurnaceRecipes;
 
-import net.minecraft.init.Blocks;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
 @ZenRegister
@@ -21,21 +20,21 @@ import net.minecraft.item.ItemStack;
 public class BlastFurnace {
 	
 	private static class ActionAddRecipe implements IAction{
-		private ItemStack input1;
-		private ItemStack input2;
+		private RecipesCommon.AStack input1;
+		private RecipesCommon.AStack input2;
 		private ItemStack output;
-		public ActionAddRecipe(IItemStack input1, IItemStack input2, IItemStack output){
-			this.input1 = CraftTweakerMC.getItemStack(input1);
-			this.input2 = CraftTweakerMC.getItemStack(input2);
+		public ActionAddRecipe(IIngredient input1, IIngredient input2, IItemStack output){
+			this.input1 = NTMCraftTweaker.IIngredientToAStack(input1);
+			this.input2 =  NTMCraftTweaker.IIngredientToAStack(input2);
 			this.output = CraftTweakerMC.getItemStack(output);
 		}
 		@Override
 		public void apply(){
-			if(this.input1 == null || this.input1.isEmpty()){
+			if(this.input1 == null){
 				CraftTweakerAPI.logError("ERROR Blast Furnace input 1 item can not be an empty/air stack!");
 				return;
 			}
-			if(this.input2 == null || this.input2.isEmpty()){
+			if(this.input2 == null){
 				CraftTweakerAPI.logError("ERROR Blast Furnace input 2 item can not be an empty/air stack!");
 				return;
 			}
@@ -43,7 +42,7 @@ public class BlastFurnace {
 				CraftTweakerAPI.logError("ERROR Blast Furnace recipe output item can not be an empty/air stack!");
 				return;
 			}
-			DiFurnaceRecipes.addRecipe(new ComparableStack(this.input1), new ComparableStack(this.input2), this.output);
+			DiFurnaceRecipes.addRecipe(this.input1, this.input2, this.output);
 		}
 		@Override
 		public String describe(){
@@ -62,12 +61,23 @@ public class BlastFurnace {
 		private ItemStack input1;
 		private ItemStack input2;
 
+		private ItemStack output;
+
 		public ActionRemoveRecipe(IItemStack input1, IItemStack input2){
 			this.input1 = CraftTweakerMC.getItemStack(input1);
 			this.input2 = CraftTweakerMC.getItemStack(input2);
 		}
+
+		public ActionRemoveRecipe(IItemStack output){
+			this.output = CraftTweakerMC.getItemStack(output);
+		}
 		@Override
 		public void apply(){
+			if(this.output != null && !this.output.isEmpty()){
+				DiFurnaceRecipes.removeRecipe(this.output);
+				return;
+			}
+
 			if(this.input1 == null || this.input1.isEmpty()){
 				CraftTweakerAPI.logError("ERROR Blast Furnace input 1 item can not be an empty/air stack!");
 				return;
@@ -89,11 +99,22 @@ public class BlastFurnace {
 		NTMCraftTweaker.postInitActions.add(new ActionRemoveRecipe(input1, input2));
 	}
 
+	@ZenMethod
+	public static void removeRecipe(IItemStack output){
+		NTMCraftTweaker.postInitActions.add(new ActionRemoveRecipe(output));
+	}
+
+	@ZenMethod
+	public static void replaceRecipe(IItemStack  output,IIngredient input1, IIngredient input2){
+		NTMCraftTweaker.postInitActions.add(new ActionRemoveRecipe(output));
+		NTMCraftTweaker.postInitActions.add(new ActionAddRecipe(input1, input2, output));
+	}
+
 	public static class ActionAddFuel implements IAction{
 		private ItemStack input;
 		private int heatLvl = 0;
 
-		public ActionAddFuel(IItemStack input, int heatLvl){
+		public ActionAddFuel(IIngredient input, int heatLvl){
 			this.input = CraftTweakerMC.getItemStack(input);
 			this.heatLvl = heatLvl;
 		}
@@ -116,7 +137,7 @@ public class BlastFurnace {
 	}
 
 	@ZenMethod
-	public static void addFuel(IItemStack input, int heatLvl){
+	public static void addFuel(IIngredient input, int heatLvl){
 		NTMCraftTweaker.postInitActions.add(new ActionAddFuel(input, heatLvl));
 	}
 

--- a/src/main/java/com/hbm/handler/crt/NTMCraftTweaker.java
+++ b/src/main/java/com/hbm/handler/crt/NTMCraftTweaker.java
@@ -38,12 +38,12 @@ public class NTMCraftTweaker {
 			return new RecipesCommon.OreDictStack(((IOreDictEntry) ingredient).getName());
 		}
 		if(ingredient instanceof IngredientStack){
-			IIngredient  ingredient2 = (IIngredient) ((IngredientStack) ingredient).getInternal();
+			IIngredient  ingredient2 = (IIngredient) ingredient.getInternal();
 			if(ingredient2 instanceof IItemStack){
 				return new RecipesCommon.ComparableStack(CraftTweakerMC.getItemStack((IItemStack) ingredient2));
 			}
 			if(ingredient2 instanceof IOreDictEntry){
-				return new RecipesCommon.OreDictStack(((IOreDictEntry) ingredient2).getName());
+				return new RecipesCommon.OreDictStack(((IOreDictEntry) ingredient2).getName(), ingredient.getAmount());
 			}
 		}
 		CraftTweakerAPI.logError("ERROR: Unknown ingredient type: " + ingredient.getClass().getName());

--- a/src/main/java/com/hbm/handler/crt/NTMCraftTweaker.java
+++ b/src/main/java/com/hbm/handler/crt/NTMCraftTweaker.java
@@ -3,11 +3,20 @@ package com.hbm.handler.crt;
 import java.util.List;
 import java.util.ArrayList;
 
+import com.hbm.inventory.RecipesCommon;
+import com.hbm.inventory.RecipesCommon.AStack;
 import com.hbm.main.MainRegistry;
 import com.hbm.inventory.RBMKOutgasserRecipes;
 
 import crafttweaker.IAction;
 import crafttweaker.CraftTweakerAPI;
+import crafttweaker.api.item.IIngredient;
+import crafttweaker.api.item.IItemStack;
+import crafttweaker.api.item.IngredientStack;
+import crafttweaker.api.minecraft.CraftTweakerMC;
+import crafttweaker.api.oredict.IOreDictEntry;
+
+import javax.annotation.Nullable;
 
 public class NTMCraftTweaker {
 	public static final List<IAction> postInitActions = new ArrayList<>();
@@ -18,5 +27,34 @@ public class NTMCraftTweaker {
 		} catch( final Throwable t ){
 			MainRegistry.logger.info("CraftTweaker integration decativated");
 		}
+	}
+
+	@Nullable
+	public static AStack IIngredientToAStack(IIngredient ingredient){
+		if(ingredient instanceof IItemStack){
+			return new RecipesCommon.ComparableStack(CraftTweakerMC.getItemStack((IItemStack) ingredient));
+		}
+		if(ingredient instanceof IOreDictEntry){
+			return new RecipesCommon.OreDictStack(((IOreDictEntry) ingredient).getName());
+		}
+		if(ingredient instanceof IngredientStack){
+			IIngredient  ingredient2 = (IIngredient) ((IngredientStack) ingredient).getInternal();
+			if(ingredient2 instanceof IItemStack){
+				return new RecipesCommon.ComparableStack(CraftTweakerMC.getItemStack((IItemStack) ingredient2));
+			}
+			if(ingredient2 instanceof IOreDictEntry){
+				return new RecipesCommon.OreDictStack(((IOreDictEntry) ingredient2).getName());
+			}
+		}
+		CraftTweakerAPI.logError("ERROR: Unknown ingredient type: " + ingredient.getClass().getName());
+		return null;
+	}
+
+	public static AStack[] IIngredientsToAStack(IIngredient[] ingredients){
+		AStack[] result = new AStack[ingredients.length];
+		for(int i = 0; i < ingredients.length; i++){
+			result[i] = IIngredientToAStack(ingredients[i]);
+		}
+		return result;
 	}
 }

--- a/src/main/java/com/hbm/handler/crt/Press.java
+++ b/src/main/java/com/hbm/handler/crt/Press.java
@@ -1,0 +1,72 @@
+package com.hbm.handler.crt;
+
+import com.hbm.inventory.PressRecipes;
+import com.hbm.inventory.RecipesCommon;
+import crafttweaker.CraftTweakerAPI;
+import crafttweaker.IAction;
+import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.item.IIngredient;
+import crafttweaker.api.item.IItemStack;
+import crafttweaker.api.minecraft.CraftTweakerMC;
+import net.minecraft.item.ItemStack;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+
+@ZenRegister
+@ZenClass("mods.ntm.Press")
+public class Press {
+
+	@ZenMethod
+	public static void addRecipe(IItemStack output, IIngredient inputs, int type) {
+		CraftTweakerAPI.apply(new ActionAddRecipe(output, inputs, type));
+	}
+
+	@Nullable
+	public static PressRecipes.PressType toType(int type) {
+		if (type >= 0 && type < PressRecipes.PressType.values().length) {
+			return PressRecipes.PressType.values()[type];
+		} else {
+			return null;
+		}
+	}
+	private static class ActionAddRecipe implements IAction {
+
+		private RecipesCommon.AStack inputs;
+
+		private ItemStack output;
+
+		private int type;
+
+		public ActionAddRecipe(IItemStack output, IIngredient inputs, int type) {
+			this.output = CraftTweakerMC.getItemStack(output);
+			this.inputs = NTMCraftTweaker.IIngredientToAStack(inputs);
+			this.type = type;
+		}
+
+		@Override
+		public void apply() {
+			PressRecipes.PressType toType = toType(this.type);
+			if(toType == null) {
+				CraftTweakerAPI.logError("Invalid press type: " + this.type);
+				return;
+			}
+			if(this.output == null) {
+				CraftTweakerAPI.logError("Invalid press output" );
+				return;
+			}
+			if(this.inputs == null) {
+				CraftTweakerAPI.logError("Invalid press inputs" );
+				return;
+			}
+			PressRecipes.addRecipe(toType(this.type), this.inputs, this.output);
+		}
+
+		@Override
+		public String describe() {
+			return "Adding NTM Press recipe ("+ this.inputs +" -> "+this.output+")";
+		}
+	}
+}

--- a/src/main/java/com/hbm/handler/crt/Press.java
+++ b/src/main/java/com/hbm/handler/crt/Press.java
@@ -21,7 +21,7 @@ public class Press {
 
 	@ZenMethod
 	public static void addRecipe(IItemStack output, IIngredient inputs, int type) {
-		CraftTweakerAPI.apply(new ActionAddRecipe(output, inputs, type));
+		NTMCraftTweaker.postInitActions.add(new ActionAddRecipe(output, inputs, type));
 	}
 
 	@Nullable

--- a/src/main/java/com/hbm/inventory/AnvilRecipes.java
+++ b/src/main/java/com/hbm/inventory/AnvilRecipes.java
@@ -739,19 +739,20 @@ public class AnvilRecipes {
 		return false;
 	}
 
-	public static boolean removeConstructionRecipeByInput(ItemStack[] inputs) {
+	public static boolean removeConstructionRecipeByInput(AStack[] inputs) {
 		start:
 		for(AnvilConstructionRecipe constructionRecipe : constructionRecipes) {
 			// check length same
 			if(constructionRecipe.input.size() != inputs.length) continue;
 			// check outputs same
 			for(int i = 0; i < inputs.length; i++) {
-				if(!areItemStacksEqual(constructionRecipe.input.get(i).getStack(),inputs[i])){
+				if(!inputs[i].equals(constructionRecipe.input.get(i))){
 					continue start;
 				}
 			}
 			CraftTweakerAPI.logInfo("remove anvil recipe"+ constructionRecipe );
 			constructionRecipes.remove(constructionRecipe);
+			return true;
 		}
 		return false;
 	}

--- a/src/main/java/com/hbm/inventory/AnvilRecipes.java
+++ b/src/main/java/com/hbm/inventory/AnvilRecipes.java
@@ -721,24 +721,47 @@ public class AnvilRecipes {
 	}
 
 	public static boolean removeConstructionRecipe(ItemStack[] outputs) {
+		start:
 		for(AnvilConstructionRecipe constructionRecipe : constructionRecipes) {
 			// check length same
 			if(constructionRecipe.output.size() != outputs.length) continue;
 			// check outputs same
-			boolean same = true;
 			for(int i = 0; i < outputs.length; i++) {
 				if(!areItemStacksEqual(constructionRecipe.output.get(i).stack,outputs[i])){
-					same = false;
-					break;
+					continue start;
 				}
 			}
-			if(same){
-				CraftTweakerAPI.logInfo("remove anvil recipe"+ constructionRecipe );
-				constructionRecipes.remove(constructionRecipe);
-				return true;
-			}
+			CraftTweakerAPI.logInfo("remove anvil recipe"+ constructionRecipe );
+			constructionRecipes.remove(constructionRecipe);
+			return true;
+
 		}
 		return false;
+	}
+
+	public static boolean removeConstructionRecipeByInput(ItemStack[] inputs) {
+		start:
+		for(AnvilConstructionRecipe constructionRecipe : constructionRecipes) {
+			// check length same
+			if(constructionRecipe.input.size() != inputs.length) continue;
+			// check outputs same
+			for(int i = 0; i < inputs.length; i++) {
+				if(!areItemStacksEqual(constructionRecipe.input.get(i).getStack(),inputs[i])){
+					continue start;
+				}
+			}
+			CraftTweakerAPI.logInfo("remove anvil recipe"+ constructionRecipe );
+			constructionRecipes.remove(constructionRecipe);
+		}
+		return false;
+	}
+
+	public static void addConstructionRecipe(AStack[] inputs, ItemStack[] output, int tier) {
+		AnvilOutput[] anvilOutputs = new AnvilOutput[output.length];
+		for(int i = 0; i < output.length; i++) {
+			anvilOutputs[i] = new AnvilOutput(output[i]);
+		}
+		constructionRecipes.add(new AnvilConstructionRecipe(inputs, anvilOutputs).setTier(tier));
 	}
 
 	public static class AnvilConstructionRecipe {

--- a/src/main/java/com/hbm/inventory/AnvilRecipes.java
+++ b/src/main/java/com/hbm/inventory/AnvilRecipes.java
@@ -5,9 +5,11 @@ import static com.hbm.inventory.OreDictManager.IRON;
 import static com.hbm.inventory.OreDictManager.STEEL;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static com.hbm.inventory.OreDictManager.*;
+import static net.minecraft.item.ItemStack.areItemStacksEqual;
 
 import com.hbm.blocks.ModBlocks;
 import com.hbm.config.GeneralConfig;
@@ -16,6 +18,7 @@ import com.hbm.inventory.RecipesCommon.ComparableStack;
 import com.hbm.inventory.RecipesCommon.OreDictStack;
 import com.hbm.items.ModItems;
 
+import crafttweaker.CraftTweakerAPI;
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -462,7 +465,7 @@ public class AnvilRecipes {
 		pullFromAssembler(new ComparableStack(ModItems.upgrade_nullifier), 4);
 		pullFromAssembler(new ComparableStack(ModItems.upgrade_screm), 4);
 	}
-	
+
 	public static void registerConstructionRecycling() {
 		constructionRecipes.add(new AnvilConstructionRecipe(
 				new ComparableStack(ModBlocks.solar_mirror),
@@ -716,7 +719,28 @@ public class AnvilRecipes {
 	public static List<AnvilConstructionRecipe> getConstruction() {
 		return constructionRecipes;
 	}
-	
+
+	public static boolean removeConstructionRecipe(ItemStack[] outputs) {
+		for(AnvilConstructionRecipe constructionRecipe : constructionRecipes) {
+			// check length same
+			if(constructionRecipe.output.size() != outputs.length) continue;
+			// check outputs same
+			boolean same = true;
+			for(int i = 0; i < outputs.length; i++) {
+				if(!areItemStacksEqual(constructionRecipe.output.get(i).stack,outputs[i])){
+					same = false;
+					break;
+				}
+			}
+			if(same){
+				CraftTweakerAPI.logInfo("remove anvil recipe"+ constructionRecipe );
+				constructionRecipes.remove(constructionRecipe);
+				return true;
+			}
+		}
+		return false;
+	}
+
 	public static class AnvilConstructionRecipe {
 		public List<AStack> input = new ArrayList<>();
 		public List<AnvilOutput> output = new ArrayList<>();

--- a/src/main/java/com/hbm/inventory/DiFurnaceRecipes.java
+++ b/src/main/java/com/hbm/inventory/DiFurnaceRecipes.java
@@ -6,6 +6,8 @@ import java.util.HashSet;
 import java.util.HashMap;
 
 import static com.hbm.inventory.OreDictManager.*;
+import static net.minecraft.item.ItemStack.areItemStacksEqual;
+
 import com.hbm.blocks.ModBlocks;
 import com.hbm.config.GeneralConfig;
 import com.hbm.util.Tuple.Pair;
@@ -133,6 +135,9 @@ public class DiFurnaceRecipes {
 		diRecipes.remove(new Pair(inputBottom, inputTop));
 	}
 
+	public static void removeRecipe(ItemStack output){
+		diRecipes.values().removeIf(value -> areItemStacksEqual(value,output));;
+	}
 	public static void addFuel(AStack fuel, int power){
 		diFuels.put(fuel, power);
 	}


### PR DESCRIPTION
I'm creating a modpack using HBM and when trying to use CRT, I found that it doesn't allow the use of the Ore Dictionary.
The pr allow the CRT to use the Ore Dictionary when adding assembly machine recipes.