### PR TITLE
Correct the purpose of a line in TileEntityPileBase.java

### DIFF
--- a/src/main/java/com/hbm/tileentity/machine/pile/TileEntityPileBase.java
+++ b/src/main/java/com/hbm/tileentity/machine/pile/TileEntityPileBase.java
@@ -54,7 +54,7 @@ public abstract class TileEntityPileBase extends TileEntity implements ITickable
 			if(te instanceof IPileNeutronReceiver) {
 				
 				//this part throttles neutron efficiency for reactions that are way too close, efficiency reaches 100% after 2.5 meters
-				float mult = Math.min((float)range / 2.5F, 1F);
+				float mult = Math.min((float)i / 2.5F, 1F);
 				int n = (int)(flux * mult);
 				
 				IPileNeutronReceiver rec = (IPileNeutronReceiver) te;


### PR DESCRIPTION
range is the max distance of the ray, so a constant, the distance beetween the source and the target is i (corected to be compliant with the comment)