### PR TITLE
fix: avoid neighbor-notify recursion in MudBlock.reactToBlocks

### DIFF
--- a/src/main/java/com/hbm/blocks/fluid/MudBlock.java
+++ b/src/main/java/com/hbm/blocks/fluid/MudBlock.java
@@ -118,7 +118,7 @@ public class MudBlock extends BlockFluidClassic {
 			IBlockState block = world.getBlockState(pos);
 			
 			if(block.getMaterial().isLiquid()) {
-				world.setBlockToAir(pos);
+				world.setBlockState(pos, Blocks.AIR.getDefaultState(), 2);
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #522 

## Problem

`MudBlock.reactToBlocks` calls `world.setBlockToAir(pos)` to remove adjacent liquids on neighbor changes. `setBlockToAir` is implemented as `setBlockState(pos, AIR, 3)`, where flag `3 = NOTIFY_NEIGHBORS | SEND_TO_CLIENTS`. The `NOTIFY_NEIGHBORS` bit re-enters `BlockStaticLiquid.neighborChanged` on adjacent water (which turns it dynamic and flowing), which schedules further neighbor updates that re-enter `MudBlock.neighborChanged` → infinite recursion → `StackOverflowError` when mud is placed next to water.

## Fix

Use flag `2` (`SEND_TO_CLIENTS` only). The liquid is still removed, clients still see the update; we just don't trigger the neighbor-notify chain that causes the recursion. Adjacent water will receive its own scheduled update on the next tick and behave normally.

```diff
 	public void reactToBlocks(World world, BlockPos pos) {
 		if(world.getBlockState(pos).getMaterial() != Material.LAVA) {
 			IBlockState block = world.getBlockState(pos);
 			
 			if(block.getMaterial().isLiquid()) {
-				world.setBlockToAir(pos);
+				world.setBlockState(pos, Blocks.AIR.getDefaultState(), 2);
 			}
 		}
 	}
```

## Behavior change

None observable to players, except that the crash no longer happens. Adjacent water might appear to flow one tick later than before, which is well within the mod's existing 15-tick `tickRate`.

## Why not also patch `reactToBlocks2`?

`reactToBlocks2` is invoked from `updateTick` only. It removes blocks via `setBlockToAir` too, but because `updateTick` is scheduled (not synchronous like `neighborChanged`), the cascade does not reach the same depth in practice. Keeping this PR minimal and focused on the actual crash source. Happy to extend the same pattern to `reactToBlocks2` for consistency if the maintainer prefers.
